### PR TITLE
Fast hex loader

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,15 +20,15 @@ DDE is designed for systems with at least 24k of RAM (i.e, `21446` Bytes Free up
 
 Built into this project is a test campaign that flexes features of the engine. Other projects that wish to use this engine should be able to simply use `zasm` with the `--8080` argument and include `src/engine/dde.asm`.
 
-Only the raw binary is created for the test campaign, at `build/test_campaign.hex`. A build step that adds a `CO` file header is coming _Eventually™_. It is meant to be loaded at `$C000` (`49152`). This process will eventually be less painful.
+Only the raw binary is created for the test campaign, at `build/test_campaign.hex`. It is meant to be loaded at `$C000` (`49152`).
 
 Before either method, get into the BASIC prompt and run `clear 256, 49152`.
 
 ### Physical Model 100
 
-If you have a serial connection established with a PC running an application that can send ascii files, you can use the `loadhx.ba` BASIC program under `utils`. It will wait for an intel hex format file to be sent over `COM:88N1E` and `POKE` each byte into memory beginning at `$C000`. You'll want to run the `clear` command above before loading `loadhx` into BASIC. It will immediately start waiting for the first byte of the hex file when run, so start it before triggering file send.
+If you have a serial connection established with a PC running an application that can send ascii files, this repository includes a two-step process to transfer the campaign binary to it. For the first step, run `clear 256, 45056`, as we'll be using some higher memory than the campaign itself. Transfer the `loadhx.ba` BASIC program under `utils` to your machine and start it up. It will await an intel hex format file and begin poking it into `$B000` (`45056`). Send over `build/ldhx.hex`. Note that this first loader script is slow, and has only been proven to work consistently through [`Tera Term`](https://tera-term.en.softonic.com/) with a 50ms delay between characters. It will only be used to load the faster loader. When it is complete, an assembly-language version of essentially this same application will be loaded, and you can save it for easier re-use now with `savem "ldhx",45056,45560,45056`. Once this is complete, you'll want to delete the original `loadhx.do` file to make some room.
 
-> **Note:** This has only been tested with [`Tera Term`](https://tera-term.en.softonic.com/) and a 50ms delay between characters.
+Once the fast loader is loaded, running it will once again wait for an intel hex format file, only now it will begin inserting at `$C000` (`49152`). This loader is much faster, and has proven stable with only a 5ms delay between characters.
 
 ### Virtual-T
 

--- a/src/apps/tests/main.asm
+++ b/src/apps/tests/main.asm
@@ -80,6 +80,7 @@ rom_file_end:
 
 math_tests:
     call test_multiplication
+    call test_parse_hex
     ret
 
 test_multiplication:
@@ -107,6 +108,21 @@ test_multiplication:
     ld b, 24
     call mul_a_b
 .expect a = 24
+    ret
+
+test_parse_hex:
+    ld a, "0"
+    call parse_a_as_hex_digit
+.expect a = 0
+    ld a, "9"
+    call parse_a_as_hex_digit
+.expect a = 9
+    ld a, "A"
+    call parse_a_as_hex_digit
+.expect a = 10
+    ld a, "F"
+    call parse_a_as_hex_digit
+.expect a = 15
     ret
 
 .macro DECIMAL_TEST &D, &E, &D1, &D2, &D3

--- a/src/engine/constants.asm
+++ b/src/engine/constants.asm
@@ -38,6 +38,9 @@
 #define ch_corner_lower_left $FE
 #define ch_corner_lower_right $FC
 
+#define ch_line_feed $0A
+#define ch_carriage_return $0D
+
 ; analogous mappings
 #charset map "┌" = $F0
 #charset map "┐" = $F2

--- a/src/engine/rom_api.asm
+++ b/src/engine/rom_api.asm
@@ -15,6 +15,10 @@
 #define rom_inlin $4644
 #define rom_enter_reverse_video $4269
 #define rom_exit_reverse_video $426E
+#define rom_setser $17E6
+#define rom_clscom $6ECB
+#define rom_rcvx $6D6D
+#define rom_rv232c $6D7E
 
 ; memory locations
 #define seconds_10s $F934

--- a/src/engine/string.asm
+++ b/src/engine/string.asm
@@ -150,3 +150,19 @@ decimal_count_loop_end:
     ret
 
 .endlocal
+
+.local
+; parses A into its numeric value
+parse_a_as_hex_digit::
+    ; ascii 0-9 is 48-57. A-F is 65-70
+    cp a, 58
+    jp m, val_0_9
+
+    ; it's A-F. Only subtract 55 (not 65) since A is 10
+    sub a, 55
+    ret
+
+val_0_9:
+    sub a, 48
+    ret
+.endlocal

--- a/utils/loadhx.ba
+++ b/utils/loadhx.ba
@@ -2,7 +2,7 @@
 20 'com stats
 21 cs$ = "COM:88N1E"
 22 'start address
-23 sa% = -16384
+23 sa% = -20480
 
 50 ad% = sa%
 60 open cs$ for input as 1


### PR DESCRIPTION
Campaigns reached the point where the slow BASIC loader was taking 40+ minutes to load them. This points the old BASIC loader higher in memory and adds a native loader app that takes us down to about 6-7 minutes to load an 11k campaign.