### PR TITLE
refactor: add iterate_a

### DIFF
--- a/src/apps/ldhx/main.asm
+++ b/src/apps/ldhx/main.asm
@@ -8,6 +8,7 @@
 #define start_address $B200
 #include "../../engine/constants.asm"
 #include "../../engine/rom_api.asm"
+#include "../../engine/util.asm"
 #include "../../engine/string.asm"
 #include "../../engine/hex_string.asm"
 

--- a/src/apps/tests/main.asm
+++ b/src/apps/tests/main.asm
@@ -313,11 +313,66 @@ test_class_mechanics:
 .expect a = 30
     ret
 
+iterate_a_total: .db 0
+iterate_a_test_body_1:
+    ld b, a
+    ld a, (iterate_a_total)
+    add a, b
+    ld (iterate_a_total), a
+    ret
+
+iterate_a_inner_total: .db 0
+iterate_a_nested_body_inner:
+    ld b, a
+    ld a, (iterate_a_inner_total)
+    add a, b
+    ld (iterate_a_inner_total), a
+    ret
+
+iterate_a_outer_total: .db 0
+iterate_a_nested_body_outer:
+    ld b, a
+    ld a, (iterate_a_outer_total)
+    add a, b
+    ld (iterate_a_outer_total), a
+
+    ld a, 6
+    ld hl, iterate_a_nested_body_inner
+    call iterate_a
+    ret
+
+iterate_a_tests:
+    ld a, 0
+    ld (iterate_a_total), a
+
+    ld a, 10
+    ld hl, iterate_a_test_body_1
+    call iterate_a
+
+    ld a, (iterate_a_total)
+.expect a = 45
+
+    ld a, 0
+    ld (iterate_a_inner_total), a
+    ld (iterate_a_outer_total), a
+
+    ld a, 5
+    ld hl, iterate_a_nested_body_outer
+    call iterate_a
+
+    ld a, (iterate_a_outer_total)
+.expect a = 10
+    ld a, (iterate_a_inner_total)
+.expect a = 75
+
+    ret
+
 test_start:
     call math_tests
     call test_decimal
     call array_tests
     call test_class_mechanics
+    call iterate_a_tests
     ret
 
 test_entry:

--- a/src/engine/battle_ui/action_window.asm
+++ b/src/engine/battle_ui/action_window.asm
@@ -95,17 +95,25 @@ enemy_turn_pick_target:
     ret
 
 clear_action_window:
-    PRINT_AT_LOCATION 1, action_menu_column, blank_window_string
-    PRINT_AT_LOCATION 2, action_menu_column, blank_window_string
-    PRINT_AT_LOCATION 3, action_menu_column, blank_window_string
-    PRINT_AT_LOCATION 4, action_menu_column, blank_window_string
-    PRINT_AT_LOCATION 5, action_menu_column, blank_window_string
-    PRINT_AT_LOCATION 6, action_menu_column, blank_window_string
+    ld a, 6
+    ld hl, clear_action_window_callback
+    call iterate_a
+    ret
+
+clear_action_window_callback:
+    inc a
+    PRINT_AT_LOCATION a, action_menu_column, blank_window_string
     ret
 
 clear_message_rows:
-    PRINT_AT_LOCATION 7, 1, blank_message_row_string
-    PRINT_AT_LOCATION 8, 1, blank_message_row_string
+    ld a, 2
+    ld hl, clear_message_rows_callback
+    call iterate_a
+    ret
+
+clear_message_rows_callback:
+    add a, 7
+    PRINT_AT_LOCATION a, 1, blank_message_row_string
     ret
 
 print_turn_header:

--- a/src/engine/battle_ui/battle_ui.asm
+++ b/src/engine/battle_ui/battle_ui.asm
@@ -76,7 +76,7 @@ on_enemy_party_dead:
     ld hl, victory_text
     call print_string
 
-    call await_any_key
+    call await_any_keypress
 
     ld a, 1
     ret
@@ -84,12 +84,6 @@ on_enemy_party_dead:
 init_screen_graphics:
     call rom_clear_screen
     call draw_combatants
-    ret
-
-await_any_key:
-await_any_key_loop:
-    call rom_kyread
-    jp z, await_any_key_loop
     ret
 
 .endlocal

--- a/src/engine/battle_ui/combatant_window.asm
+++ b/src/engine/battle_ui/combatant_window.asm
@@ -1,5 +1,3 @@
-
-; combat_row_buffer: .asciz "      "
 combat_string_buffer: .asciz "   "
 #define enemy_screen_column 1
 #define party_screen_column 4
@@ -8,13 +6,17 @@ combat_string_buffer: .asciz "   "
 #define enemy_front_index 2
 #define party_front_index 0
 
-combat_draw_player_index: .db 0
 combat_draw_player_sprite: .db 0
 draw_combatants:
-    ld a, 0
-    ld (combat_draw_player_index), a
+    ld a, (total_number_of_combatants)
+    ld hl, draw_combatants_callback
+    call iterate_a
+    ret
 
-draw_combatants_loop:
+draw_combatants_callback:
+    ld b, a
+    push bc
+
     ; clear the buffer
     ld a, " "
     ld (combat_string_buffer + 0), a
@@ -22,7 +24,9 @@ draw_combatants_loop:
     ld (combat_string_buffer + 2), a
 
     ; read flags
-    ld a, (combat_draw_player_index)
+    pop bc
+    push bc
+    ld a, b
     call get_combatant_at_index_a
     LOAD_A_WITH_ATTR_THROUGH_HL cbt_offs_flags
     ld c, a
@@ -48,7 +52,7 @@ check_line:
     ; back is same index on either side
     ld a, (combat_draw_player_sprite)
     ld (combat_string_buffer + back_index), a
-    jp draw_combatants_loop_continue
+    jp draw_combatants_continue
 
 draw_combatant_front:
     ld a, c
@@ -57,14 +61,16 @@ draw_combatant_front:
     jp nz, draw_combatant_front_enemy
     ld a, (combat_draw_player_sprite)
     ld (combat_string_buffer + party_front_index), a
-    jp draw_combatants_loop_continue
+    jp draw_combatants_continue
 
 draw_combatant_front_enemy:
     ld a, (combat_draw_player_sprite)
     ld (combat_string_buffer + enemy_front_index), a
 
-draw_combatants_loop_continue:
-    ld a, (combat_draw_player_index)
+draw_combatants_continue:
+    ld hl, 1
+    add hl, sp
+    ld a, (hl)
     ld b, combat_start_row
     add a, b
     ld l, a
@@ -74,7 +80,7 @@ draw_combatants_loop_continue:
     and a, b
     jp nz, draw_combatant_enemy_column
     ld h, party_screen_column
-    jp draw_combatants_loop_print
+    jp draw_combatants_print
 
 draw_combatant_enemy_column:
     ld h, enemy_screen_column
@@ -83,17 +89,10 @@ draw_combatant_enemy_column:
     sub a, b
     ld l, a
 
-draw_combatants_loop_print:
+draw_combatants_print:
     call rom_set_cursor
     ld hl, combat_string_buffer
     call print_string
 
-    ld a, (combat_draw_player_index)
-    inc a
-    ld (combat_draw_player_index), a
-    ld b, a
-    ld a, (total_number_of_combatants)
-    cp a, b
-    jp nz, draw_combatants_loop
-
+    pop bc
     ret

--- a/src/engine/battle_ui/initiative.asm
+++ b/src/engine/battle_ui/initiative.asm
@@ -73,27 +73,32 @@ init_enemy_combatant:
 initialize_combatants_foreach_callback_done:
     ret
 
-
-initiative_counter: .db 0
 display_initiative_order:
     call rom_clear_screen
 
     PRINT_AT_LOCATION 1, 1, initiative_header
 
-    ld a, 0
-    ld (initiative_counter), a
+    ld a, (total_number_of_combatants)
+    ld hl, display_initiative_order_callback
+    call iterate_a
 
-display_initiative_order_loop:
-    ld a, (initiative_counter)
-    inc a
+    call await_any_keypress
+    ret
+
+display_initiative_order_callback:
+    ld b, a
+    push bc
 
     ld h, 25
     ld l, a
+    inc l
     call rom_set_cursor
 
-    ld hl, initiative_order
-    ld a, (initiative_counter)
+    pop bc
+    push bc
+    ld a, b
     ld b, 2
+    ld hl, initiative_order
     call get_array_item
     ld a, (hl)
 
@@ -104,16 +109,17 @@ display_initiative_order_loop:
     ld hl, bc
     call print_string
 
-    ld a, (initiative_counter)
-    inc a
-
+    pop bc
+    push bc
+    ld l, b
+    inc l
     ld h, 14
-    ld l, a
     call rom_set_cursor
 
-    ld hl, initiative_order
-    ld a, (initiative_counter)
+    pop bc
+    ld a, b
     ld b, 2
+    ld hl, initiative_order
     call get_array_item
     inc hl
     ld a, (hl)
@@ -121,17 +127,5 @@ display_initiative_order_loop:
     call get_character_at_index_a
     POINT_HL_TO_ATTR pl_offs_name
     call print_string
-
-    ld a, (initiative_counter)
-    inc a
-    ld (initiative_counter), a
-    ld b, a
-    ld a, (total_number_of_combatants)
-    cp a, b
-    jp nz, display_initiative_order_loop
-
-initiative_order_wait_loop:
-    call rom_kyread
-    jp z, initiative_order_wait_loop
 
     ret

--- a/src/engine/character_wizard/roll_abilities_ui.asm
+++ b/src/engine/character_wizard/roll_abilities_ui.asm
@@ -205,16 +205,9 @@ init_screen:
 roll_loop:
     ld (ability_index), a
     ; You're supposed to roll 4 and add the highest 3. Just gonna roll 3 for simplicity for now.
-    call roll_d6
-    ld a, l
-    ld (ability_roll_total), a
-    call roll_d6
-    ld a, (ability_roll_total)
-    add l
-    ld (ability_roll_total), a
-    call roll_d6
-    ld a, (ability_roll_total)
-    add l
+    ld a, 6
+    ld b, 3
+    call roll_b_a
 
     ld d, a
 

--- a/src/engine/dice.asm
+++ b/src/engine/dice.asm
@@ -131,37 +131,29 @@ roll_a::
 .endlocal
 
 .local
-; rolls an A die B times, and returns the total in A
 roll_total: .db 0
-roll_counter: .db 0
-roll_target: .db 0
 roll_die: .db 0
+
+; rolls an A die B times, and returns the total in A
 roll_b_a::
     ld (roll_die), a
-    ld a, b
-    ld (roll_target), a
-
     ld a, 0
     ld (roll_total), a
-    ld (roll_counter), a
 
-roll_loop:
+    ld a, b
+    ld hl, roll_b_a_callback
+    call iterate_a
+
+    ld a, (roll_total)
+    ret
+
+roll_b_a_callback:
     ld a, (roll_die)
     call roll_a
     ld b, a
     ld a, (roll_total)
     add a, b
     ld (roll_total), a
-
-    ld a, (roll_counter)
-    inc a
-    ld (roll_counter), a
-    ld b, a
-    ld a, (roll_target)
-    cp a, b
-    jp nz, roll_loop
-
-    ld a, (roll_total)
 
     ret
 .endlocal

--- a/src/engine/exploration_ui.asm
+++ b/src/engine/exploration_ui.asm
@@ -445,13 +445,16 @@ interact_bail:
     ret
 
 clear_exploration_message_area::
-    PRINT_AT_LOCATION 2, 21, blank_20_char_string
-    PRINT_AT_LOCATION 3, 21, blank_20_char_string
-    PRINT_AT_LOCATION 4, 21, blank_20_char_string
-    PRINT_AT_LOCATION 5, 21, blank_20_char_string
-    PRINT_AT_LOCATION 6, 21, blank_20_char_string
-    PRINT_AT_LOCATION 7, 21, blank_20_char_string
+    ld a, 6
+    ld hl, clear_exploration_message_area_callback
+    call iterate_a
+
     PRINT_AT_LOCATION 8, 21, blank_19_char_string
+    ret
+
+clear_exploration_message_area_callback:
+    add a, 2
+    PRINT_AT_LOCATION a, 21, blank_20_char_string
     ret
 
 configure_inputs:

--- a/src/engine/string.asm
+++ b/src/engine/string.asm
@@ -20,17 +20,20 @@ return:
 
 .local
 current_string: .dw 0
-remaining_strings: .db 0
 screen_coords: .dw 0
 
 ; Given a sequence of strings starting at HL of length A, print them in a block starting at column B row C
 block_print::
     ld (current_string), hl
-    ld (remaining_strings), a
     ld hl, bc
     ld (screen_coords), hl
 
-loop:
+    ld hl, block_print_callback
+    call iterate_a
+
+    ret
+
+block_print_callback:
     ld hl, (screen_coords)
     call rom_set_cursor
     inc l
@@ -40,12 +43,6 @@ loop:
     call print_string
     inc hl ; careful... assumes print_string left HL at the last string's terminator
     ld (current_string), hl
-
-    ld a, (remaining_strings)
-    dec a
-    ld (remaining_strings), a
-    cp a, 0
-    jp nz, loop
 
     ret
 .endlocal

--- a/src/engine/ui_components/consolidate_menu.asm
+++ b/src/engine/ui_components/consolidate_menu.asm
@@ -5,7 +5,6 @@ src_menu: .dw 0
 dst_menu: .dw 0
 full_item_count: .db 0
 final_item_count: .db 0
-scan_index: .db 0
 
 consolidate_menu_hl_bc::
     ld (src_menu), hl
@@ -15,20 +14,29 @@ consolidate_menu_hl_bc::
     ld (full_item_count), a
     ld a, 0
     ld (final_item_count), a
-    ld (scan_index), a
 
-consolidate_loop:
+    ld a, (full_item_count)
+    ld hl, consolidate_callback
+    call iterate_a
+
+    ld a, (final_item_count)
+    ret
+
+consolidate_callback:
+    ld b, a
+    ld a, mi_data_size
     ld hl, (src_menu)
-    ld bc, mi_offs_flags
-    add hl, bc
-    ld a, (hl)
-    ld b, $01
-    and a, b
-    jp z, consolidate_loop_continue
+    call get_array_item
+    ld de, hl
+
+    LOAD_A_WITH_ATTR_THROUGH_HL mi_offs_flags
+    ld c, $01
+    and a, c
+    jp z, consolidate_callback_done
 
     ld hl, (dst_menu)
     ld bc, hl
-    ld hl, (src_menu)
+    ld hl, de
     ld a, mi_data_size
     call copy_hl_bc
 
@@ -41,20 +49,6 @@ consolidate_loop:
     inc a
     ld (final_item_count), a
 
-consolidate_loop_continue:
-    ld hl, (src_menu)
-    ld bc, mi_data_size
-    add hl, bc
-    ld (src_menu), hl
-
-    ld a, (scan_index)
-    inc a
-    ld (scan_index), a
-    ld b, a
-    ld a, (full_item_count)
-    cp a, b
-    jp nz, consolidate_loop
-
-    ld a, (final_item_count)
+consolidate_callback_done:
     ret
 .endlocal

--- a/src/engine/util.asm
+++ b/src/engine/util.asm
@@ -52,3 +52,47 @@ loop:
     jp z, loop
     ret
 .endlocal
+
+.local
+; given a count in A and a callback in HL, call the callback A times.
+; A will be set to the current index before HL is called
+; for (i = 0; i < A; i++) { HL(i (passed through A) ); }
+iterate_a::
+    push hl
+    ld b, a
+    ld c, 0
+    push bc
+
+iterate_a_loop:
+    ld hl, 0
+    add hl, sp
+    ld a, (hl)
+    ld b, a
+    inc hl
+    ld a, (hl)
+    cp a, b
+    jp z, iterate_a_done
+
+    ld hl, 2
+    add hl, sp
+    ld a, (hl)
+    ld c, a
+    inc hl
+    ld a, (hl)
+    ld b, a
+    ld hl, 0
+    add hl, sp
+    ld a, (hl)
+    ld hl, bc
+    call call_hl
+
+    pop bc
+    inc c
+    push bc
+    jp iterate_a_loop
+
+iterate_a_done:
+    pop hl
+    pop hl
+    ret
+.endlocal


### PR DESCRIPTION
Adds a subroutine, `iterate_a`, to handle de-duplication of basic for loops and applies it to all easy places. Saved 153 bytes