### PR TITLE
Initial text compressor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build
+__pycache__
+.vscode

--- a/src/engine/string.asm
+++ b/src/engine/string.asm
@@ -3,9 +3,9 @@ newline_string:
 .db ch_carriage_return
 .db 0
 
+.local
 ; Prints the string starting at HL
 ; Destroys HL, a
-.local
 print_string::
 loop:
     ld a, (hl) ; read character
@@ -19,10 +19,49 @@ return:
 .endlocal
 
 .local
+; Prints the compressed string starting at HL
+; Destroys HL, a, bc
+print_compressed_string::
+loop:
+    ld a, (hl)
+    cp a, 0
+    jp z, return
+
+    ld b, a
+    and a, $80
+    cp a, 0
+    ld a, b
+    jp nz, compressed_sequence
+
+    ; it's just a regular character
+    call rom_print_a
+    inc hl
+    jp loop
+
+compressed_sequence:
+    push hl
+
+    ld bc, (hl)
+    ; the pointer is stored big-endian so the flag can live in the MSB
+    ; we don't need to clear the flag, since we load at $b200 and we know it'll always be set anyway
+    ld h, c
+    ld l, b
+    call print_string
+
+    pop hl
+    inc hl
+    inc hl
+    jp loop
+
+return:
+    ret
+.endlocal
+
+.local
 current_string: .dw 0
 screen_coords: .dw 0
 
-; Given a sequence of strings starting at HL of length A, print them in a block starting at column B row C
+; Given a sequence of compressed strings starting at HL of length A, print them in a block starting at column B row C
 block_print::
     ld (current_string), hl
     ld hl, bc
@@ -40,16 +79,16 @@ block_print_callback:
     ld (screen_coords), hl
 
     ld hl, (current_string)
-    call print_string
-    inc hl ; careful... assumes print_string left HL at the last string's terminator
+    call print_compressed_string
+    inc hl ; careful... assumes print_compressed_string left HL at the last string's terminator
     ld (current_string), hl
 
     ret
 .endlocal
 
-.macro BLOCK_PRINT &FIRST_STR, &STR_COUNT, &COL, &START_ROW
-    ld hl, &FIRST_STR
-    ld a, &STR_COUNT
+.macro BLOCK_PRINT &BLOCK_NAME, &COL, &START_ROW
+    ld hl, &BLOCK_NAME
+    ld a, &BLOCK_NAME_lines
     ld b, &COL
     ld c, &START_ROW
     call block_print

--- a/tools/compressor/__main__.py
+++ b/tools/compressor/__main__.py
@@ -1,0 +1,30 @@
+import sys
+import json
+import argparse
+
+from compressor import Compressor
+
+def process_args():
+    parser = argparse.ArgumentParser(
+        prog='DDE Text Compressor',
+        description='Compresses text for the Dungeon Delver Engine')
+
+    parser.add_argument('-i', '--input', dest='input', type=open, help='JSON Input file', required=True)
+    parser.add_argument('-o', '--output', dest='output', type=argparse.FileType('w'), help='Output assembly file',
+                        default=sys.stdout)
+
+    result = parser.parse_args()
+
+    return result
+
+def main():
+    args = process_args()
+
+    compressor = Compressor(json.load(args.input))
+    sequence_table = compressor.compress()
+    output_string = compressor.create_assembly_file(sequence_table)
+
+    args.output.write(output_string)
+
+if __name__ == '__main__':
+    main()

--- a/tools/compressor/compressor.py
+++ b/tools/compressor/compressor.py
@@ -1,0 +1,65 @@
+from line_table import LineTable, Reference
+
+def sequence_label(id):
+    return 'cs_' + str(id)
+
+class Compressor:
+    """Compresses blocks of text"""
+    def __init__(self, input_dict):
+        self.line_table = LineTable(input_dict)
+
+    def compress(self):
+        final_sequence_table = {}
+        sequence_id = 0
+        saved = 0
+
+        while len(self.line_table.remaining_strings()) != 0:
+            all_sequences = self.line_table.get_sequence_tables()
+            top_sequence = all_sequences[0]
+            if top_sequence['score'] < 0:
+                break
+
+            remove_string = top_sequence['string']
+            final_sequence_table[remove_string] = sequence_id
+            print('Removing', '"' + remove_string + '"', top_sequence['score'])
+
+            saved += top_sequence['score']
+
+            self.line_table.replace_string(remove_string, sequence_id)
+
+            sequence_id += 1
+
+        print('saved', saved, 'bytes')
+        return final_sequence_table
+
+    def create_assembly_file(self, sequence_table):
+        output_str = 'compressed_sequences:\n'
+        for sequence in sequence_table:
+            output_str += sequence_label(sequence_table[sequence]) + ': .asciz "' + sequence + '"\n'
+
+        output_str += '\n'
+
+        for block in self.line_table.blocks.values():
+            output_str += '#define ' + block.key + '_lines ' + str(len(block.lines)) + '\n'
+            output_str += block.key + ':\n'
+
+            line_index = 0
+
+            for line in block.lines:
+                output_str += "; " + block.key + "_line_" + str(line_index) + "\n"
+                line_index += 1
+
+                for chunk in line.chunks:
+                    if isinstance(chunk, str):
+                        output_str += '.ascii "' + chunk + '"\n'
+                    elif isinstance(chunk, Reference):
+                        # need to make this explicitly big-endian so the flag can be in the correct byte in the string
+                        # the first bit is a "flag" because we load at $b200, past $8000, so it'll always be set
+                        # all ascii characters printable in this form are below $80
+                        output_str += '.db hi(' + sequence_label(chunk.id) + ')\n'
+                        output_str += '.db lo(' + sequence_label(chunk.id) + ')\n'
+
+                output_str += '.db 0\n\n'
+
+
+        return output_str

--- a/tools/compressor/compressor.py
+++ b/tools/compressor/compressor.py
@@ -29,7 +29,7 @@ class Compressor:
 
             sequence_id += 1
 
-        print('saved', saved, 'bytes')
+        print('saved approximately', saved, 'bytes of text')
         return final_sequence_table
 
     def create_assembly_file(self, sequence_table):

--- a/tools/compressor/line_table.py
+++ b/tools/compressor/line_table.py
@@ -1,0 +1,132 @@
+from functools import reduce
+
+class Reference:
+    def __init__(self, id):
+        self.id = id
+
+def map_chunk(chunk, text, id):
+    if isinstance(chunk, Reference) or not text in chunk:
+        return [chunk]
+
+    sub_chunks = []
+    remaining_text = chunk
+
+    while text in remaining_text:
+        start = remaining_text.find(text)
+        before = remaining_text[0:start]
+
+        if before != '':
+            sub_chunks.append(before)
+
+        sub_chunks.append(Reference(id))
+
+        remaining_text = remaining_text[start + len(text):]
+
+    if remaining_text != '':
+        sub_chunks.append(remaining_text)
+
+    return sub_chunks
+
+class Line:
+    def __init__(self, line):
+        self.chunks = [line]
+
+    def remaining_strings(self):
+        return list(filter(lambda x: isinstance(x, str), self.chunks))
+
+    def replace_string(self, text, id):
+        new_chunks = []
+        for chunk in self.chunks:
+            result = map_chunk(chunk, text, id)
+            new_chunks.extend(result)
+
+        self.chunks = new_chunks
+
+class Block:
+    def __init__(self, key, lines):
+        self.key = key
+        self.lines = list(map(lambda x: Line(x), lines))
+
+    def remaining_strings(self):
+        line_strs = []
+        for line in self.lines:
+            line_strs.extend(line.remaining_strings())
+
+        return line_strs
+
+    def replace_string(self, text, id):
+        for line in self.lines:
+            line.replace_string(text, id)
+
+
+def build_sequence_table(all_strings, target_length):
+    sequence_dict = {}
+    for str in all_strings:
+        if len(str) < target_length:
+            continue
+
+        start_index = 0
+        while start_index + target_length <= len(str):
+            window = str[start_index:start_index + target_length]
+            if window in sequence_dict:
+                sequence_dict[window] += 1
+            else:
+                sequence_dict[window] = 1
+
+            start_index += 1
+
+    return sequence_dict
+
+class LineTable:
+    """Tracks the state text that needs to be put into the table."""
+
+    def __init__(self, from_json):
+        self.blocks = {}
+
+        for key in from_json:
+            self.blocks[key] = Block(key, from_json[key])
+
+    def replace_string(self, text, id):
+        """Within all lines of all blocks, replace instances of text with a reference to id"""
+        for block in self.blocks.values():
+            block.replace_string(text, id)
+
+    def get_sequence_tables(self):
+            """
+            Gets a list of all sequences of at least size 1, sorted by 'score'. 'Score' here is (l * c) - (2 * c) - l,
+            where l is the length of the string and c is the number of instances of that substring. This is the number
+            of bytes saved by extracting one instance of that string to a table and replacing all instances of it with a
+            two-byte reference ID.
+            """
+            sequence_tables = {}
+            all_sequences = []
+            all_strings = self.remaining_strings()
+            max_length = max(list(map(lambda x: len(x), all_strings)))
+
+            for i in range(1, max_length + 1):
+                table = build_sequence_table(all_strings, i)
+                sequence_tables[i] = table
+
+                for sequence_str in table:
+                    sequence = {}
+                    sequence['string'] = sequence_str
+                    sequence['count'] = table[sequence_str]
+                    sequence['size'] = i
+                    sequence['score'] = (i * table[sequence_str]) - (table[sequence_str] * 2) - i
+                    all_sequences.append(sequence)
+
+            all_sequences = sorted(all_sequences, key=lambda sequence: sequence['score'])
+            all_sequences.reverse()
+
+            return all_sequences
+
+    def remaining_strings(self):
+        """Gets all strings in the table not currently replaced with a reference."""
+        all_lines = []
+
+        for block in self.blocks.values():
+            remaining_strings = block.remaining_strings()
+            if len(remaining_strings) > 0:
+                all_lines.extend(remaining_strings)
+
+        return all_lines

--- a/tools/compressor/line_table.py
+++ b/tools/compressor/line_table.py
@@ -93,10 +93,11 @@ class LineTable:
 
     def get_sequence_tables(self):
             """
-            Gets a list of all sequences of at least size 1, sorted by 'score'. 'Score' here is (l * c) - (2 * c) - l,
+            Gets a list of all sequences of at least size 1, sorted by 'score'. 'Score' here is:
+                (l * c) - (2 * c) - l - 1,
             where l is the length of the string and c is the number of instances of that substring. This is the number
             of bytes saved by extracting one instance of that string to a table and replacing all instances of it with a
-            two-byte reference ID.
+            two-byte reference ID. -1 more for the additional null terminator.
             """
             sequence_tables = {}
             all_sequences = []
@@ -112,7 +113,7 @@ class LineTable:
                     sequence['string'] = sequence_str
                     sequence['count'] = table[sequence_str]
                     sequence['size'] = i
-                    sequence['score'] = (i * table[sequence_str]) - (table[sequence_str] * 2) - i
+                    sequence['score'] = (i * table[sequence_str]) - (table[sequence_str] * 2) - i - 1
                     all_sequences.append(sequence)
 
             all_sequences = sorted(all_sequences, key=lambda sequence: sequence['score'])


### PR DESCRIPTION
Adds basic text compression. Algorithm works by brute-force finding the best sequence of characters to commonize and pulling it out to a table until it can't find any left that would save any space. "Best" in this case is defined by the formula:

> (l * c) - (2 * c) - l - 1

Where `l` is the length of the string, and `c` is the number of time it's used. This is the number of bytes saved by extracting one instance of that string to a table and replacing all instances of it with a two-byte reference ID. -1 more for the additional null terminator.

This also adds `print_compressed_string` and updates `BLOCK_PRINT` to use it.

The algorithm likely has room for improvement, but saves approximately 335 bytes of text (62ish of which are taken back up by `print_compressed_string`) in the "flagship" project (no the test campaign) for this library.