### PR TITLE
Exploration UI Overhaul

### DIFF
--- a/src/apps/test_campaign/screens/screen_1.asm
+++ b/src/apps/test_campaign/screens/screen_1.asm
@@ -26,16 +26,16 @@ screen_1_title: .asciz "Test Room"
 screen_1_start_x: .db 2 ; 1-indexed since it's screen coordinates!
 screen_1_start_y: .db 2
 screen_1_interactables:
-    DEFINE_INTERACTABLE chest_1, in_chest, 0, 3, 13
-    DEFINE_INTERACTABLE door_1, in_door, $01, 2, 20
-    DEFINE_INTERACTABLE test_npc, in_npc, 0, 2, 6
-    DEFINE_INTERACTABLE blank_4, 0, 0, 0, 0
-    DEFINE_INTERACTABLE blank_5, 0, 0, 0, 0
-    DEFINE_INTERACTABLE blank_6, 0, 0, 0, 0
-    DEFINE_INTERACTABLE blank_7, 0, 0, 0, 0
-    DEFINE_INTERACTABLE blank_8, 0, 0, 0, 0
-    DEFINE_INTERACTABLE blank_9, 0, 0, 0, 0
-    DEFINE_INTERACTABLE blank_0, 0, 0, 0, 0
+    DEFINE_INTERACTABLE chest_1, in_chest, iflags_normal, 3, 13
+    DEFINE_INTERACTABLE door_1, in_door, iflags_door, 2, 20
+    DEFINE_INTERACTABLE test_npc, in_npc, iflags_normal, 2, 6
+    DEFINE_INTERACTABLE blank_4, 0, iflags_normal, 0, 0
+    DEFINE_INTERACTABLE blank_5, 0, iflags_normal, 0, 0
+    DEFINE_INTERACTABLE blank_6, 0, iflags_normal, 0, 0
+    DEFINE_INTERACTABLE blank_7, 0, iflags_normal, 0, 0
+    DEFINE_INTERACTABLE blank_8, 0, iflags_normal, 0, 0
+    DEFINE_INTERACTABLE blank_9, 0, iflags_normal, 0, 0
+    DEFINE_INTERACTABLE blank_0, 0, iflags_normal, 0, 0
 screen_1_get_interaction_prompt: .dw get_interaction_prompt
 screen_1_interact_callback: .dw on_interact
 screen_1_menu_callback: .dw main_menu
@@ -82,7 +82,6 @@ on_interact:
 
 chest_interact:
     call dialog_skill_demo
-    ld a, 0
     ret
 
 door_interact:

--- a/src/apps/test_campaign/screens/screen_2.asm
+++ b/src/apps/test_campaign/screens/screen_2.asm
@@ -24,16 +24,16 @@ screen_2_title: .asciz "Test Room 2"
 screen_2_start_x: .db 2 ; 1-indexed since it's screen coordinates!
 screen_2_start_y: .db 2
 screen_2_interactables:
-    DEFINE_INTERACTABLE door_1, in_door, $01, 2, 1
-    DEFINE_INTERACTABLE blank_1, 0, 0, 0, 0
-    DEFINE_INTERACTABLE blank_3, 0, 0, 0, 0
-    DEFINE_INTERACTABLE blank_4, 0, 0, 0, 0
-    DEFINE_INTERACTABLE blank_5, 0, 0, 0, 0
-    DEFINE_INTERACTABLE blank_6, 0, 0, 0, 0
-    DEFINE_INTERACTABLE blank_7, 0, 0, 0, 0
-    DEFINE_INTERACTABLE blank_8, 0, 0, 0, 0
-    DEFINE_INTERACTABLE blank_9, 0, 0, 0, 0
-    DEFINE_INTERACTABLE blank_0, 0, 0, 0, 0
+    DEFINE_INTERACTABLE door_1, in_door, iflags_door, 2, 1
+    DEFINE_INTERACTABLE blank_1, 0, iflags_normal, 0, 0
+    DEFINE_INTERACTABLE blank_3, 0, iflags_normal, 0, 0
+    DEFINE_INTERACTABLE blank_4, 0, iflags_normal, 0, 0
+    DEFINE_INTERACTABLE blank_5, 0, iflags_normal, 0, 0
+    DEFINE_INTERACTABLE blank_6, 0, iflags_normal, 0, 0
+    DEFINE_INTERACTABLE blank_7, 0, iflags_normal, 0, 0
+    DEFINE_INTERACTABLE blank_8, 0, iflags_normal, 0, 0
+    DEFINE_INTERACTABLE blank_9, 0, iflags_normal, 0, 0
+    DEFINE_INTERACTABLE blank_0, 0, iflags_normal, 0, 0
 screen_2_get_interaction_prompt: .dw get_interaction_prompt
 screen_2_interact_callback: .dw on_interact
 screen_2_menu_callback: .dw main_menu

--- a/src/engine/constants.asm
+++ b/src/engine/constants.asm
@@ -135,14 +135,14 @@
 #define pl_data_size pl_offs_name + pl_name_data_len
 
 ; interactables data
-#define in_type_offset 0
-#define in_flags_offset 1
-#define in_row_offset 2
-#define in_col_offset 3
-#define in_data_length 4 ; type, flags, row, col
+#define in_offs_type 0
+#define in_offs_flags in_offs_type + 1
+#define in_offs_row in_offs_flags + 1
+#define in_offs_col in_offs_row + 1
+#define in_data_size in_offs_col + 1
 
 ; flags fields (msb-lsb):
-; 7: reserved
+; 7: is enabled
 ; 6: reserved
 ; 5: reserved
 ; 4: reserved
@@ -151,12 +151,15 @@
 ; 1: reserved
 ; 0: is trigger (interact on location match)
 
+#define iflags_normal $80
+#define iflags_door $81
+
 ; screen data structure
 #define sc_background_data_len 21 * 8
 #define sc_title_max_len 20
 #define sc_title_data_len sc_title_max_len + 1
 #define sc_interactable_array_elements 10
-#define sc_interactable_array_length in_data_length * sc_interactable_array_elements
+#define sc_interactable_array_length in_data_size * sc_interactable_array_elements
 
 #define sc_offs_background 0
 #define sc_offs_title sc_background_data_len


### PR DESCRIPTION
Establishes the MSB of the interactables flags as the "enabled" flag. The previous way of disabling the interactable was to move it off screen, but a later refactor to use the item's location to clear its graphic meant that clearing was no longer idempotent. To make that less painful to use, it also finally adds constants for the common flags. Also gets back quite a few bytes by turning some of the bigger macros into subroutines.
