### PR TITLE
[Not Merging] Investigate Huffman Coding

### DIFF
--- a/tools/compressor/__main__.py
+++ b/tools/compressor/__main__.py
@@ -4,6 +4,7 @@ import argparse
 import os
 
 from compressor import Compressor
+from huffman import huffman_test
 
 engine_text_path = './engine_text.json'
 
@@ -30,11 +31,13 @@ def main():
             input_json = json.load(input_file)
             engine_json.update(input_json)
 
-    compressor = Compressor(engine_json)
-    sequence_table = compressor.compress()
-    output_string = compressor.create_assembly_file(sequence_table)
+    huffman_test(engine_json)
 
-    args.output.write(output_string)
+    # compressor = Compressor(engine_json)
+    # sequence_table = compressor.compress()
+    # output_string = compressor.create_assembly_file(sequence_table)
+
+    # args.output.write(output_string)
 
 if __name__ == '__main__':
     main()

--- a/tools/compressor/huffman.py
+++ b/tools/compressor/huffman.py
@@ -1,0 +1,169 @@
+from math import ceil
+
+class Line:
+    def __init__(self, text):
+        self.text = text
+
+class Block:
+    def __init__(self, key, lines):
+        self.key = key
+        if isinstance(lines, str):
+            lines = [lines]
+
+        self.lines = list(map(lambda x: Line(x), lines))
+
+
+class LineTable:
+    def __init__(self, from_json):
+        self.blocks = {}
+
+        for key in from_json:
+            self.blocks[key] = Block(key, from_json[key])
+
+    def for_all_text(self, callback):
+        for key in self.blocks:
+            block = self.blocks[key]
+            for line in block.lines:
+                callback(line.text)
+
+    def total_original_text_size(self):
+        total = 0
+        for key in self.blocks:
+            block = self.blocks[key]
+            for line in block.lines:
+                total += len(line.text)
+
+        return total
+
+class HuffmanNode:
+    def __init__(self):
+        return
+
+    def traverse(self, callback, depth):
+        if not self.is_internal:
+            callback(self, depth)
+        else:
+            self.left.traverse(callback, depth + 1)
+            callback(self, depth)
+            self.right.traverse(callback, depth + 1)
+
+    def internal(left, right):
+        node = HuffmanNode()
+        node.is_internal = True
+        node.left = left
+        node.right = right
+        node.count = left.count + right.count
+        return node
+
+    def leaf(value, count):
+        node = HuffmanNode()
+        node.is_internal = False
+        node.value = value
+        node.count = count
+        return node
+
+class HuffmanQueue:
+    def __init__(self, raw_frequencies):
+        self.nodes = [ HuffmanNode.leaf(ch, raw_frequencies[ch]) for ch in raw_frequencies ]
+
+    def pop_lowest(self):
+        lowest_two = []
+
+        while len(lowest_two) < 2 and len(self.nodes) > 0:
+            lowest = min(self.nodes, key=lambda x: x.count)
+            lowest_two.append(lowest)
+            self.nodes = [ node for node in self.nodes if node != lowest ]
+
+        return lowest_two
+
+    def add(self, node):
+        self.nodes.append(node)
+
+class HuffmanGenerator:
+    def __init__(self, from_json):
+        self.line_table = LineTable(from_json)
+        self.frequencies = {}
+
+    def generate_tree(self):
+        self.line_table.for_all_text(lambda text: self.process_line(text))
+        queue = HuffmanQueue(self.frequencies)
+
+        lowest = queue.pop_lowest()
+        while len(lowest) == 2:
+            queue.add(HuffmanNode.internal(lowest[0], lowest[1]))
+            lowest = queue.pop_lowest()
+
+        return lowest[0]
+
+    def process_line(self, line):
+        for char in line:
+            if char in self.frequencies:
+                self.frequencies[char] += 1
+            else:
+                self.frequencies[char] = 1
+
+def huffman_test(json):
+    g = HuffmanGenerator(json)
+    tree = g.generate_tree()
+
+    leaves = []
+
+    def add_leaf(node, depth):
+        if node.is_internal:
+            return
+
+        leaves.append([node, depth])
+
+    tree.traverse(add_leaf, 0)
+
+    total_bits = 0
+    for leaf in leaves:
+        print(leaf[0].value, leaf[0].count, leaf[1], leaf[0].count * leaf[1], ceil((leaf[0].count * leaf[1]) / 8))
+        total_bits += leaf[0].count * leaf[1]
+
+    # approx_bytes here is the ideal total if the whole game's text was one contiguous string
+    approx_bytes = ceil(total_bits / 8)
+    original_total = g.line_table.total_original_text_size()
+    print("total ideal bytes", approx_bytes, "down from", original_total, "saved", original_total - approx_bytes)
+
+    # To get a little more realistic, we know we'll need at least one semaphore byte per string (haven't made any
+    # encoding choices at the time of writing, but it'd probably be a leading length byte). We also can't realistically
+    # pack the entire thing without trailing bits at the end of each string's last byte.
+
+    char_map = {}
+    for leaf in leaves:
+        char_map[leaf[0].value] = leaf
+
+    unpacked_total = 0
+
+    def total_line(line):
+        # start at one for the length byte (or whatever)
+        line_total = 1
+
+        bit_total = 0
+        for ch in line:
+            bit_total = bit_total + char_map[ch][1]
+
+        # ceil because the last byte will have trailing bits if not filled
+        line_total = line_total + ceil(bit_total / 8)
+
+        return line_total
+
+    for key in g.line_table.blocks:
+        block = g.line_table.blocks[key]
+        for line in block.lines:
+            unpacked_total += total_line(line.text)
+
+    print("total unpacked bytes", unpacked_total, "down from", original_total, "saved", original_total - unpacked_total)
+
+    unpacked_total_with_impl = unpacked_total
+
+    # Now approximate the minimal bytes needed in an implementation of the table. Not sure how to do it yet, but I can't
+    # imagine something taking less than two bytes per character in the table; at least one byte for the constant
+    # itself, and some kind of offset pointer.
+
+    unpacked_total_with_impl += len(leaves) * 2
+
+    print("total unpacked bytes with approximate minimal table impl", unpacked_total_with_impl, "down from", original_total, "saved", original_total - unpacked_total_with_impl)
+
+    return


### PR DESCRIPTION
```shell
total ideal bytes 3069 down from 5267 saved 2198
total unpacked bytes 3520 down from 5267 saved 1747
total unpacked bytes with approximate minimal table impl 3646 down from 5267 saved 1621
```

This branch will not be merged, but I'm using this PR to save this work for posterity and possible future reconsideration, and as a coherent log of the investigation.

The current compression technique is a quick-and-dirty dictionary coder that saves approximately `1547` bytes in the "flagship" project for DDE. That algorithm was chosen as the implementation of any compression technique in this small of a memory space also needs to be small enough to not eat too much into the saved bytes. To that end, [Huffman Coding](https://en.wikipedia.org/wiki/Huffman_coding) is reasonably simple in theory, but I've been skeptical of my ability to keep the `asm` side small enough. I was also unsure whether the compression ratio itself would be better than the dictionary coder at this size, though something with more formal definition and usage certainly seemed promising. Another major advantage would be the allowance of special characters (above `127`) in compressed text.

To allay the curiosity, I put together a very quick and hacky Huffman table generator that could at least represent the tree in Python and allow some analysis of its characteristics against the flagship project's actual text. Specifically, it allowed me to see the best possible compression performance, as well as speculate about where I would spend more bytes to implement it in `asm`.

Short answer: Doesn't currently seem worth it. 

Long answer:
The flagship project currently has `5267` total bytes of text with only `63` unique characters. The generated Huffman tree found ` ` (space) as the most-used character, with some parts of the tree reaching a depth of `12`. That is, the most-used characters were shortened from `8` bits down to `3`, while the least-used were extended from `8` up to `12`, with a broad spectrum in between.

Ideally, given the specific depths of each character times its number of occurrences, the best possible way to encode that text would shorten it down to `3069` bytes, assuming all of them were packed tightly together with no sort of table. That's a savings of `2198` bytes, about `651` bytes better than the dictionary coder, with no consideration for the implementation, which initially at least seemed promising.

From here, though, I began to speculate about the cost of the implementation. First off, we need _some_ way to know how long each string is. Any implementation I can think of would require at least one byte per individual string. Realistically, I would want each string to start on a proper byte offset, so we'll incur up to 7 bits of padding per string no matter how we order things. Even if we kept it packed, the addressing system would need an extra three bits per string somewhere for a bit offset.

So, now, I totaled up the byte length of each individual string as its length in compressed bits divided by 8 rounded up, plus a byte for the length. That increased the compressed size of the text to `3520` bytes total, a mere `200` byte improvement from the dictionary compressor, without accounting for the binary version of the Huffman table or any necessary code to use it.

The final addition to the estimate is the least-thought-out, but I added an additional two bytes per unique character to the total. We need a byte for the character itself, and any method of referencing it I can think of (e.g. as a constant to `ld a, <char>`, an offset index into a table, etc...) would take at least one more byte. This bumped us up to at least `3646` bytes.

At this point, I had a potential savings of just `74` bytes over the current compressor, even with very optimistic guesses at support code size. If used only as a drop-in replacement for existing compression, that would not be a significant enough savings to justify further exploration.

That said, it _does_ still have the advantage of arbitrary characters, meaning fully "graphical" screens could be stored in text blocks. It would also allow for some compressibility in room background data, which currently occupies a total of `1120` bytes in the flagship project. Naively multiplying that by our ideal ratio of `3069:5267` says it could _maybe_ save us another `468` bytes, but that would require a heafty refactor.

For now, though, it just isn't worth `¯\_(ツ)_/¯`