### PR TITLE
Implement Melee Combat Distance

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,10 +50,8 @@ DDE follows a typical RPG setup with screens for exploration, combat, and dialog
     - Each side has its own two lines, for a total of 4.
     - Players are limited to their side's lines.
     - Players may move between lines at least once each turn.
-        - Stretch goal: Allow players with a high enough movement speed to make multiple moves in one turn.
     - Normal melee rules apply when attacker and defender are 1 line apart (both in the "front"). If both players are in the back line, they are out of melee range. If one player is in the back and the other the front, the attacker has disadvantage. (If there was a hard range cutoff, then ranged characters could always beat melee-only combatants by never going up front in this system.)
-    - Ranged attacks more-or-less follow SRD rules, but the range is determined by battle line distance, and ranges of weapons and spells are defined in terms of that distance. For example, a short bow may work normally with the attacker in the back and the defender in the front, and have disadvantage if the defender is also in the back. A long bow, then, would not have disadvantage at long distance. Both bows would have disadvantage if both attacker and defender are in the front.
-    - Stretch goal: Opportunity attacks still fit in with this system, if you consider 1 line of distance normal melee range.
+    - Ranged combat currently just assumes players are in the spell's normal range.
 
 ## Architecture
 

--- a/src/engine/battle_ui/action_window.asm
+++ b/src/engine/battle_ui/action_window.asm
@@ -378,6 +378,24 @@ return_distance:
     ld a, c
     ret
 
+roll_d20_with_advantage:
+    ld hl, str_advantage_parenthetical
+    call print_compressed_string
+
+    call roll_d20
+    ld b, a
+    push bc
+    call roll_d20
+    pop bc
+
+    cp a, b
+    jp c, return_b
+    ret
+
+return_b:
+    ld a, b
+    ret
+
 try_hit_selected_enemy:
     call clear_message_rows
     ld h, 1
@@ -387,7 +405,12 @@ try_hit_selected_enemy:
     ld hl, attack_roll_str
     call print_compressed_string
 
-    call roll_d20
+    call get_selected_enemy_distance
+    cp a, 0
+
+    call nz, roll_d20
+    call z, roll_d20_with_advantage
+
     ld (attack_result), a
 
     cp a, 1

--- a/src/engine/class_mechanics/class_mechanics.asm
+++ b/src/engine/class_mechanics/class_mechanics.asm
@@ -164,8 +164,6 @@ cleric_apply_medium_armor:
     ld b, a
     ld a, 14; Scale Mail
     add a, b
-    ld b, 2 ; shield
-    add a, b
     ret
 
 get_barbarian_ac:

--- a/tools/compressor/engine_text.json
+++ b/tools/compressor/engine_text.json
@@ -42,6 +42,7 @@
 
     "str_too_far": "Too far",
     "str_advantage_parenthetical": "(Adv.)",
+    "str_attacking": "Attacking ",
 
     "spell_option_firebolt_label": "Fire Bolt",
     "spell_option_sacred_flame_label": "Sacred Flame",

--- a/tools/compressor/engine_text.json
+++ b/tools/compressor/engine_text.json
@@ -41,6 +41,7 @@
     "opt_bm_option_end_turn_label": "End Turn",
 
     "str_too_far": "Too far",
+    "str_advantage_parenthetical": "(Adv.)",
 
     "spell_option_firebolt_label": "Fire Bolt",
     "spell_option_sacred_flame_label": "Sacred Flame",

--- a/tools/compressor/engine_text.json
+++ b/tools/compressor/engine_text.json
@@ -40,6 +40,8 @@
     "opt_bm_option_inspect_label": "Inspect",
     "opt_bm_option_end_turn_label": "End Turn",
 
+    "str_too_far": "Too far",
+
     "spell_option_firebolt_label": "Fire Bolt",
     "spell_option_sacred_flame_label": "Sacred Flame",
 


### PR DESCRIPTION
Finally makes movement in combat matter by disallowing melee attacks if both combatants are in the back line, and providing advantage on hit if both are in the front. Also removes the plan for position to impact ranged attacks for now, drops the cleric's shield for sake of balance, and upgrades enemy AI to pick random players instead of the first living one.