### PR TITLE
fix(roll_ability_check): use ability modifier instead of score

### DIFF
--- a/src/engine/class_mechanics/class_mechanics.asm
+++ b/src/engine/class_mechanics/class_mechanics.asm
@@ -66,6 +66,7 @@ roll_ability_check::
     ld c, a
     add hl, bc
     ld a, (hl)
+    call ability_score_to_modifier
     ld b, a
     push bc
     call roll_d20


### PR DESCRIPTION
Because 1.0 can never be perfect, I missed that I was adding raw ability score to skill checks instead of the modifier, making any check (all one of them in mol 🙄) completely trivial.